### PR TITLE
modernize install path: pip install, python>=3.10, slim binary callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,22 +17,38 @@ full of summaries output by the code or
 a tree sequence. 
 
 ## Installation
-To install `slim_magic` take the following steps, starting with
-cloning this repo
+
+`slim_magic` is an ipython extension that shells out to the `slim`
+binary. SLiM itself is **not** installed by pip — install it
+separately from https://messerlab.org/slim/ (SLiM 5 or newer is
+required for the current examples) and make sure `slim` is on your
+`$PATH`.
+
+Clone the repo:
 
 ```
-$ git clone git@github.com:andrewkern/slim_magic.git
+$ git clone https://github.com/andrewkern/slim_magic.git
 $ cd slim_magic
 ```
-(optional) create a new conda environment or similar
+
+(optional) create a fresh environment with Python 3.10 or newer:
+
 ```
-$ conda create -n slim_magic python=3.8 --yes
+$ conda create -n slim_magic python=3.11 --yes
 $ conda activate slim_magic
 ```
-that will take a minute. now install the
-`slim_magic` ipython extension
+
+Install the extension with pip:
+
 ```
-$ python setup.py install
+$ pip install .
+```
+
+To also pull in the optional dependencies used by the example
+notebook (`jupyter`, `msprime`, `matplotlib`):
+
+```
+$ pip install '.[notebook]'
 ```
 ## usage
 Currently there are four separate magic functions implemented, please

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,11 @@
 from codecs import open as codecs_open
-from setuptools import setup, find_packages
-from warnings import warn
+from setuptools import setup
 import os
 
 
-# Get the long description from the relevant file
 with codecs_open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
-# After exec'ing this file we have tskit_version defined.
-tskit_version = None  # Keep PEP8 happy.
 version_file = os.path.join("slim_magic", "_version.py")
 with open(version_file) as f:
     exec(f.read())
@@ -28,21 +24,21 @@ setup(name='slim_magic',
       packages=['slim_magic'],
       include_package_data=True,
       zip_safe=False,
+      python_requires='>=3.10',
       install_requires=[
-          'msprime>=1.0.1',
-          'tskit',
-          'kastore',
-          'numpy',
+          'ipython',
           'pandas',
-          'jupyter',
-          'matplotlib'],
+          'tskit',
+      ],
       extras_require={
-          'dev': [],
+          'notebook': [
+              'jupyter',
+              'matplotlib',
+              'msprime>=1.0.1',
+          ],
       },
-
-      setup_requires=[],
       project_urls={
           'Bug Reports': 'https://github.com/andrewkern/slim_magic/issues',
-          'Source': 'https://github.com/andrewkern/slim_magic/pyslim',
+          'Source': 'https://github.com/andrewkern/slim_magic',
       },
       )

--- a/slim_magic/_version.py
+++ b/slim_magic/_version.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-slim_magic_version = '0.0666'
+slim_magic_version = '0.666'
 slim_file_version = '0.7'
 # other file versions that require no modification
 compatible_slim_file_versions = ['0.7']


### PR DESCRIPTION
## Summary
- README: replace deprecated `python setup.py install` with `pip install .`, bump suggested python from 3.8 (EOL) to 3.11, and call out that SLiM itself is not pip-installable
- setup.py: trim `install_requires` to deps actually imported (ipython, pandas, tskit); move jupyter/matplotlib/msprime into `extras_require['notebook']`; add `python_requires>=3.10`; drop dead `find_packages` import, stale `tskit_version` line, empty `setup_requires`, and empty `dev` extra; fix the `Source` URL that had a stray `/pyslim` suffix
- `_version.py`: `0.0666` -> `0.666` so the declared version matches PEP 440 normalization (and what `pip show` reports)
- new `pyproject.toml`: minimal `[build-system]` table so pip uses the standards-based build backend instead of the legacy `setup.py` fallback

## Test plan
- [x] `pip install .` in a fresh Python 3.12 venv builds via pyproject.toml and installs cleanly (~30 deps, down from ~140)
- [x] `pip show slim_magic` reports version `0.666`
- [x] `python -c "import slim_magic"` succeeds
- [ ] Manual: `%load_ext slim_magic` + run a cell from `example_magic.ipynb` end to end against a local SLiM 5 install